### PR TITLE
Ability to handle values that are not numbers

### DIFF
--- a/dual-gauge-card.js
+++ b/dual-gauge-card.js
@@ -127,12 +127,12 @@ class DualGaugeCard extends HTMLElement {
   _getEntityStateValue(entity, attribute) {
     if (!attribute) {
       if(isNaN(entity.state)) return "-" ; //check if entity state is NaN
-      else return (Math.round(entity.state*10)/10); //rounds the value to 1 decimal place
+      else return entity.state;
     }
 
     // return entity.attributes[attribute];
     if(isNaN(entity.attributes[attribute])) return "-" ; //check if entity attribute is NaN
-    else return (Math.round(entity.attributes[attribute]*10)/10); //rounds the value to 1 decimal place
+    else return entity.attributes[attribute];
   }
 
   _calculateRotation(value, gaugeConfig) {

--- a/dual-gauge-card.js
+++ b/dual-gauge-card.js
@@ -126,13 +126,15 @@ class DualGaugeCard extends HTMLElement {
 
   _getEntityStateValue(entity, attribute) {
     if (!attribute) {
-      return (Math.round(entity.state*10)/10); //rounds the value to 1 decimal place
+      if(isNaN(entity.state)) return "-" ; //check if entity state is NaN
+      else return (Math.round(entity.state*10)/10); //rounds the value to 1 decimal place
     }
 
-    return (Math.round(entity.attributes[attribute]*10)/10);
+    return entity.attributes[attribute];
   }
 
   _calculateRotation(value, gaugeConfig) {
+    if(isNaN(value)) return '180deg'; //check if value is NaN
     const maxTurnValue = Math.min(Math.max(value, gaugeConfig.min), gaugeConfig.max);
     return (180 + (5 * (maxTurnValue - gaugeConfig.min)) / (gaugeConfig.max - gaugeConfig.min) / 10 * 360) + 'deg';
   }

--- a/dual-gauge-card.js
+++ b/dual-gauge-card.js
@@ -126,10 +126,10 @@ class DualGaugeCard extends HTMLElement {
 
   _getEntityStateValue(entity, attribute) {
     if (!attribute) {
-      return entity.state;
+      return (Math.round(entity.state*10)/10); //rounds the value to 1 decimal place
     }
 
-    return entity.attributes[attribute];
+    return (Math.round(entity.attributes[attribute]*10)/10);
   }
 
   _calculateRotation(value, gaugeConfig) {

--- a/dual-gauge-card.js
+++ b/dual-gauge-card.js
@@ -130,7 +130,9 @@ class DualGaugeCard extends HTMLElement {
       else return (Math.round(entity.state*10)/10); //rounds the value to 1 decimal place
     }
 
-    return entity.attributes[attribute];
+    // return entity.attributes[attribute];
+    if(isNaN(entity.attributes[attribute])) return "-" ; //check if entity attribute is NaN
+    else return (Math.round(entity.attributes[attribute]*10)/10); //rounds the value to 1 decimal place
   }
 
   _calculateRotation(value, gaugeConfig) {


### PR DESCRIPTION
Added checks to verify if the entity state/attribute values are numbers or not. If it is not a number, a "-" is returned. It also rounds the values to 1 decimal place as it got quite tight when both the entities have 2 or more decimal places.